### PR TITLE
Fix: callback performed on every keyDown event

### DIFF
--- a/PinScreen.js
+++ b/PinScreen.js
@@ -223,6 +223,13 @@ class PinScreen extends Component {
   }
 
   /**
+   * Function to clear the current pin
+   */
+  clearPin() {
+    this.setState({ pin: ""});
+  }
+
+  /**
    * Callback when shake animation has completed on the pin
    */
   shakeAnimationComplete() {

--- a/PinScreen.js
+++ b/PinScreen.js
@@ -190,9 +190,11 @@ class PinScreen extends Component {
       Vibration.vibrate(50);
     }
 
-    // The pin has been changed, trigger the callback
-    // Don't allow the callback if the input exceeds the number of pins
-    if (newPin.length <= numberOfPins) {
+    // Save the new pin into the state
+    this.setState({ pin: newPin });
+
+    // If the newPin matches the required length, perform the callback
+    if (newPin.length === numberOfPins) {
       if (keyDown) keyDown(newPin);
     }
   }


### PR DESCRIPTION
The current design performs the callback on every keyDown event, rather than when the PIN is entered fully. The pins do not update either.

This fix will make the PinScreen working again.